### PR TITLE
CTCP-5729: Branching request off depending on if it is JSON or XML

### DIFF
--- a/app/connectors/CustomsReferenceDataConnector.scala
+++ b/app/connectors/CustomsReferenceDataConnector.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import config.AppConfig
+import models.BodyType
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
@@ -27,27 +28,27 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class CustomsReferenceDataConnector @Inject()(http: HttpClientV2, config: AppConfig) {
 
-  private val headers = Seq(
-    "Accept-Encoding" -> "gzip, deflate, br",
-    "Content-Type" -> "application/json",
-    "Accept" -> config.acceptHeader
-  )
-
-
-  def referenceDataListPost(body: File)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[HttpResponse] = {
-    val url = url"${config.customsReferenceDataUrl}/reference-data-lists"
+  def referenceDataListPost(body: File, bodyType: BodyType)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[HttpResponse] = {
+    val url = bodyType match {
+      case BodyType.JSON => url"${config.customsReferenceDataUrl}/reference-data-lists"
+      case BodyType.XML => url"${config.customsReferenceDataUrl}/test-only/reference-data-lists"
+    }
+    println(url)
     http
       .post(url)
-      .setHeader(headers: _*)
+      .setHeader(hc.headers(Seq("Accept", "Accept-Encoding", "Content-Type")): _*)
       .withBody(body)
       .execute[HttpResponse]
   }
 
-  def customsOfficeListPost(body: File)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[HttpResponse] = {
-    val url = url"${config.customsReferenceDataUrl}/customs-office-lists"
+  def customsOfficeListPost(body: File, bodyType: BodyType)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[HttpResponse] = {
+    val url = bodyType match {
+      case BodyType.JSON => url"${config.customsReferenceDataUrl}/customs-office-lists"
+      case BodyType.XML => url"${config.customsReferenceDataUrl}/test-only/customs-office-lists"
+    }
     http
       .post(url)
-      .setHeader(headers: _*)
+      .setHeader(hc.headers(Seq("Accept", "Accept-Encoding", "Content-Type")): _*)
       .withBody(body)
       .execute[HttpResponse]
   }
@@ -56,7 +57,7 @@ class CustomsReferenceDataConnector @Inject()(http: HttpClientV2, config: AppCon
     val url = url"${config.customsReferenceDataUrl}/lists/$listName"
     http
       .get(url)
-      .setHeader(headers: _*)
+      .setHeader(hc.headers(Seq("Accept")): _*)
       .execute[HttpResponse]
   }
 

--- a/app/connectors/CustomsReferenceDataConnector.scala
+++ b/app/connectors/CustomsReferenceDataConnector.scala
@@ -33,7 +33,6 @@ class CustomsReferenceDataConnector @Inject()(http: HttpClientV2, config: AppCon
       case BodyType.JSON => url"${config.customsReferenceDataUrl}/reference-data-lists"
       case BodyType.XML => url"${config.customsReferenceDataUrl}/test-only/reference-data-lists"
     }
-    println(url)
     http
       .post(url)
       .setHeader(hc.headers(Seq("Accept", "Accept-Encoding", "Content-Type")): _*)

--- a/app/models/BodyType.scala
+++ b/app/models/BodyType.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import uk.gov.hmrc.http.HeaderCarrier
+
+sealed trait BodyType
+
+object BodyType {
+
+  case object JSON extends BodyType
+  case object XML extends BodyType
+
+  def apply(hc: HeaderCarrier): Option[BodyType] =
+    hc.headers(Seq("Content-Type")) match {
+      case headers if headers.map(_._2).contains("application/xml") => Some(XML)
+      case headers if headers.map(_._2).contains("application/json") => Some(JSON)
+      case _ => None
+    }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,3 @@
-import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
-
 val appName = "customs-reference-data-test-frontend"
 
 lazy val microservice = Project(appName, file("."))
@@ -18,8 +15,6 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Wconf:src=routes/.*:s"
   )
   .settings(inConfig(Test)(testSettings): _*)
-  .configs(IntegrationTest)
-  .settings(integrationTestSettings(): _*)
   .settings(resolvers += Resolver.jcenterRepo)
 
 lazy val testSettings: Seq[Def.Setting[_]] = Seq(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,10 +3,10 @@
 GET        /assets/*file                        controllers.Assets.versioned(path = "/public", file: Asset)
 
 + nocsrf
-POST       /reference-data-list-ingestion       controllers.CustomsReferenceDataController.referenceDataListPost()
+POST       /reference-data-lists                controllers.CustomsReferenceDataController.referenceDataListPost()
 
 + nocsrf
-POST       /customs-office-list-ingestion       controllers.CustomsReferenceDataController.customsOfficeListPost()
+POST       /customs-office-lists                controllers.CustomsReferenceDataController.customsOfficeListPost()
 
 + nocsrf
 PUT        /schedule-action/reference-data      controllers.TransitMovementsTraderReferenceDataEtlController.referenceDataImport()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -84,5 +84,4 @@ google-analytics {
 
 footerLinkItems = ["cookies", "privacy", "termsConditions", "govukHelp"]
 
-play.http.parser.maxDiskBuffer=20M
-accept-header = "application/vnd.hmrc.1.0+gzip"
+play.http.parser.maxDiskBuffer = 150M

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 

--- a/test/connectors/CustomsReferenceDataConnectorSpec.scala
+++ b/test/connectors/CustomsReferenceDataConnectorSpec.scala
@@ -17,6 +17,7 @@
 package connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, post, urlEqualTo}
+import models.BodyType
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
@@ -44,44 +45,82 @@ class CustomsReferenceDataConnectorSpec
   "CustomsReferenceDataConnector" - {
 
     "referenceDataListPost" - {
-      "must return status Accepted" in {
+      "must return status Accepted" - {
+        "when XML" in {
+          server.stubFor(
+            post(urlEqualTo("/customs-reference-data/test-only/reference-data-lists"))
+              .willReturn(
+                aResponse()
+                  .withStatus(202)
+              )
+          )
 
-        server.stubFor(
-          post(urlEqualTo("/customs-reference-data/reference-data-lists"))
-            .willReturn(
-              aResponse()
-                .withStatus(202)
-            )
-        )
+          val tempFile = File.createTempFile("test", ".gz")
 
-        val tempFile = File.createTempFile("test", ".gz")
+          val result: Future[HttpResponse] = connector.referenceDataListPost(tempFile, BodyType.XML)
 
-        val result: Future[HttpResponse] = connector.referenceDataListPost(tempFile)
+          result.futureValue.status mustBe 202
 
-        result.futureValue.status mustBe 202
+          tempFile.deleteOnExit()
+        }
 
-        tempFile.deleteOnExit()
+        "when JSON" in {
+          server.stubFor(
+            post(urlEqualTo("/customs-reference-data/reference-data-lists"))
+              .willReturn(
+                aResponse()
+                  .withStatus(202)
+              )
+          )
+
+          val tempFile = File.createTempFile("test", ".gz")
+
+          val result: Future[HttpResponse] = connector.referenceDataListPost(tempFile, BodyType.JSON)
+
+          result.futureValue.status mustBe 202
+
+          tempFile.deleteOnExit()
+        }
       }
     }
 
     "customsOfficeListPost" - {
-      "must return status Accepted" in {
+      "must return status Accepted" - {
+        "when XML" in {
+          server.stubFor(
+            post(urlEqualTo("/customs-reference-data/test-only/customs-office-lists"))
+              .willReturn(
+                aResponse()
+                  .withStatus(202)
+              )
+          )
 
-        server.stubFor(
-          post(urlEqualTo("/customs-reference-data/customs-office-lists"))
-            .willReturn(
-              aResponse()
-                .withStatus(202)
-            )
-        )
+          val tempFile = File.createTempFile("test", ".gz")
 
-        val tempFile = File.createTempFile("test", ".gz")
+          val result: Future[HttpResponse] = connector.customsOfficeListPost(tempFile, BodyType.XML)
 
-        val result: Future[HttpResponse] = connector.customsOfficeListPost(tempFile)
+          result.futureValue.status mustBe 202
 
-        result.futureValue.status mustBe 202
+          tempFile.deleteOnExit()
+        }
 
-        tempFile.deleteOnExit()
+        "when JSON" in {
+          server.stubFor(
+            post(urlEqualTo("/customs-reference-data/customs-office-lists"))
+              .willReturn(
+                aResponse()
+                  .withStatus(202)
+              )
+          )
+
+          val tempFile = File.createTempFile("test", ".gz")
+
+          val result: Future[HttpResponse] = connector.customsOfficeListPost(tempFile, BodyType.JSON)
+
+          result.futureValue.status mustBe 202
+
+          tempFile.deleteOnExit()
+        }
       }
     }
 

--- a/test/controllers/CustomsReferenceDataControllerSpec.scala
+++ b/test/controllers/CustomsReferenceDataControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import connectors.CustomsReferenceDataConnector
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, when}
+import org.mockito.Mockito.{reset, verify, verifyNoInteractions, when}
 import org.scalacheck.Gen
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -51,7 +51,50 @@ class CustomsReferenceDataControllerSpec extends SpecBase with ScalaCheckPropert
   "CustomsReferenceDataController" - {
     "referenceDataListPost" - {
       "must return Accepted when post successful" in {
-        when(mockConnector.referenceDataListPost(any())(any(), any()))
+        when(mockConnector.referenceDataListPost(any(), any())(any(), any()))
+          .thenReturn(Future.successful(HttpResponse(ACCEPTED, "")))
+
+        val request = FakeRequest(POST, routes.CustomsReferenceDataController.referenceDataListPost().url)
+          .withHeaders(
+            "Authorization" -> bearerToken,
+            "Content-Type" -> "application/json"
+          )
+
+        val result = route(app, request).value
+
+        status(result) mustEqual ACCEPTED
+
+        val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+        verify(mockConnector).referenceDataListPost(any(), any())(any(), headerCarrierCaptor.capture())
+        headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
+      }
+
+      "must return InternalServerError when post unsuccessful" in {
+        forAll(Gen.choose(400, 599)) {
+          errorCode =>
+            beforeEach()
+
+            when(mockConnector.referenceDataListPost(any(), any())(any(), any()))
+              .thenReturn(Future.successful(HttpResponse(errorCode, "")))
+
+            val request = FakeRequest(POST, routes.CustomsReferenceDataController.referenceDataListPost().url)
+              .withHeaders(
+                "Authorization" -> bearerToken,
+                "Content-Type" -> "application/json"
+              )
+
+            val result = route(app, request).value
+
+            status(result) mustEqual INTERNAL_SERVER_ERROR
+
+            val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+            verify(mockConnector).referenceDataListPost(any(), any())(any(), headerCarrierCaptor.capture())
+            headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
+        }
+      }
+
+      "must return BadRequest when Content-Type missing" in {
+        when(mockConnector.referenceDataListPost(any(), any())(any(), any()))
           .thenReturn(Future.successful(HttpResponse(ACCEPTED, "")))
 
         val request = FakeRequest(POST, routes.CustomsReferenceDataController.referenceDataListPost().url)
@@ -61,40 +104,58 @@ class CustomsReferenceDataControllerSpec extends SpecBase with ScalaCheckPropert
 
         val result = route(app, request).value
 
-        status(result) mustEqual ACCEPTED
+        status(result) mustEqual BAD_REQUEST
 
-        val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-        verify(mockConnector).referenceDataListPost(any())(any(), headerCarrierCaptor.capture())
-        headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
-      }
-
-      "must return BadRequest when post unsuccessful" in {
-        forAll(Gen.choose(400, 599)) {
-          errorCode =>
-            beforeEach()
-
-            when(mockConnector.referenceDataListPost(any())(any(), any()))
-              .thenReturn(Future.successful(HttpResponse(errorCode, "")))
-
-            val request = FakeRequest(POST, routes.CustomsReferenceDataController.referenceDataListPost().url)
-              .withHeaders(
-                "Authorization" -> bearerToken
-              )
-
-            val result = route(app, request).value
-
-            status(result) mustEqual BAD_REQUEST
-
-            val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-            verify(mockConnector).referenceDataListPost(any())(any(), headerCarrierCaptor.capture())
-            headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
-        }
+        verifyNoInteractions(mockConnector)
       }
     }
 
     "customsOfficeListPost" - {
       "must return Accepted when post successful" in {
-        when(mockConnector.customsOfficeListPost(any())(any(), any()))
+        when(mockConnector.customsOfficeListPost(any(), any())(any(), any()))
+          .thenReturn(Future.successful(HttpResponse(ACCEPTED, "")))
+
+        val request = FakeRequest(POST, routes.CustomsReferenceDataController.customsOfficeListPost().url)
+          .withHeaders(
+            "Authorization" -> bearerToken,
+            "Content-Type" -> "application/json"
+          )
+
+        val result = route(app, request).value
+
+        status(result) mustEqual ACCEPTED
+
+        val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+        verify(mockConnector).customsOfficeListPost(any(), any())(any(), headerCarrierCaptor.capture())
+        headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
+      }
+
+      "must return InternalServerError when post unsuccessful" in {
+        forAll(Gen.choose(400, 599)) {
+          errorCode =>
+            beforeEach()
+
+            when(mockConnector.customsOfficeListPost(any(), any())(any(), any()))
+              .thenReturn(Future.successful(HttpResponse(errorCode, "")))
+
+            val request = FakeRequest(POST, routes.CustomsReferenceDataController.customsOfficeListPost().url)
+              .withHeaders(
+                "Authorization" -> bearerToken,
+                "Content-Type" -> "application/json"
+              )
+
+            val result = route(app, request).value
+
+            status(result) mustEqual INTERNAL_SERVER_ERROR
+
+            val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+            verify(mockConnector).customsOfficeListPost(any(), any())(any(), headerCarrierCaptor.capture())
+            headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
+        }
+      }
+
+      "must return BadRequest when post successful" in {
+        when(mockConnector.customsOfficeListPost(any(), any())(any(), any()))
           .thenReturn(Future.successful(HttpResponse(ACCEPTED, "")))
 
         val request = FakeRequest(POST, routes.CustomsReferenceDataController.customsOfficeListPost().url)
@@ -104,34 +165,9 @@ class CustomsReferenceDataControllerSpec extends SpecBase with ScalaCheckPropert
 
         val result = route(app, request).value
 
-        status(result) mustEqual ACCEPTED
+        status(result) mustEqual BAD_REQUEST
 
-        val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-        verify(mockConnector).customsOfficeListPost(any())(any(), headerCarrierCaptor.capture())
-        headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
-      }
-
-      "must return BadRequest when post unsuccessful" in {
-        forAll(Gen.choose(400, 599)) {
-          errorCode =>
-            beforeEach()
-
-            when(mockConnector.customsOfficeListPost(any())(any(), any()))
-              .thenReturn(Future.successful(HttpResponse(errorCode, "")))
-
-            val request = FakeRequest(POST, routes.CustomsReferenceDataController.customsOfficeListPost().url)
-              .withHeaders(
-                "Authorization" -> bearerToken
-              )
-
-            val result = route(app, request).value
-
-            status(result) mustEqual BAD_REQUEST
-
-            val headerCarrierCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-            verify(mockConnector).customsOfficeListPost(any())(any(), headerCarrierCaptor.capture())
-            headerCarrierCaptor.getValue.authorization.value.value mustBe bearerToken
-        }
+        verifyNoInteractions(mockConnector)
       }
     }
   }

--- a/test/models/BodyTypeSpec.scala
+++ b/test/models/BodyTypeSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import uk.gov.hmrc.http.HeaderCarrier
+
+class BodyTypeSpec extends SpecBase {
+
+  "BodyType" - {
+    "when XML content type" in {
+      val hc = HeaderCarrier(otherHeaders = Seq("Content-Type" -> "application/xml"))
+      val result = BodyType(hc)
+      result mustBe Some(BodyType.XML)
+    }
+
+    "when JSON content type" in {
+      val hc = HeaderCarrier(otherHeaders = Seq("Content-Type" -> "application/json"))
+      val result = BodyType(hc)
+      result mustBe Some(BodyType.JSON)
+    }
+
+    "when random content type" in {
+      val hc = HeaderCarrier(otherHeaders = Seq("Content-Type" -> "foo"))
+      val result = BodyType(hc)
+      result mustBe None
+    }
+
+    "when no content type" in {
+      val hc = HeaderCarrier()
+      val result = BodyType(hc)
+      result mustBe None
+    }
+  }
+}


### PR DESCRIPTION
Checks Content-Type header. If JSON, sends request off to prod endpoint in customs-reference-data. If XML, sends requests off to test-only endpoint in customs-reference-data, which converts the XML to JSON, before utilising the underlying logic in the prod endpoint to save the JSON to Mongo.


Also removed the accept-header config key as it is irrelevant - we can drive this directly from Postman and capture it here rather than redefine it.